### PR TITLE
Fixes #5 CPT-onomies search in not case insensitive for a non ASCII characters.

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -463,7 +463,14 @@ class CPT_ONOMIES_ADMIN {
 						
 						// We don't want to display the current post
 						// If a match was found, add it to the suggestions
-						if ( stripos( $this_term->label, $term ) !== false ) {
+						if ( function_exists( 'mb_stripos' ) && defined( 'DB_CHARSET' ) && ( DB_CHARSET === 'utf8' || DB_CHARSET === 'utf8mb4' ) ) {
+							$matches = mb_stripos( $this_term->label, $term, 0, 'UTF-8' ) === false ? false : true;
+						}
+						else {
+							$matches = stripos( $this_term->label, $term ) === false ? false : true;
+						}
+
+						if ( $matches ) {
 						
 							$results[] = array(
 								'value' => $this_term->ID,


### PR DESCRIPTION
As mb_stripos() requires a encoding specified, the proper solution will be map MySQL character sets to PHP character sets. But I believe UTF-8 would be sufficient to cover over 99% use cases.
