### PR TITLE
Fixes #9 CPT-onomies will break taxonomy queries for terms term_id and term_taxonomy_id of which are not equal

### DIFF
--- a/manager.php
+++ b/manager.php
@@ -431,8 +431,8 @@ class CPT_ONOMIES_MANAGER {
 					
 				// @TODO This used to skip for non-CPT-onomies but that caused a bug
 				// Now we let them through. Does this need to be fixed?
-				//if ( ! ( $is_registered_cpt_onomy = $this->is_registered_cpt_onomy( $taxonomy ) ) )
-				//	continue;
+				if ( ! ( $is_registered_cpt_onomy = $this->is_registered_cpt_onomy( $taxonomy ) ) )
+					continue;
 				$is_registered_cpt_onomy = $this->is_registered_cpt_onomy( $taxonomy );
 		
 				$this_query[ 'terms' ] = array_unique( (array) $this_query[ 'terms' ] );


### PR DESCRIPTION
I propose to just uncomment this part.

``` php
// @TODO This used to skip for non-CPT-onomies but that caused a bug
// Now we let them through. Does this need to be fixed?
//if ( ! ( $is_registered_cpt_onomy = $this->is_registered_cpt_onomy( $taxonomy ) ) )
//  continue;
```

If I understand correctly this was commented out because of this https://wordpress.org/support/topic/mashup-with-tax_query-not-working-on-131
I have tested this code and more, and it was working with uncommented part mentioned above.
